### PR TITLE
fix: redis default mode should be `copy`

### DIFF
--- a/pages/configuration/databases/redis.mdx
+++ b/pages/configuration/databases/redis.mdx
@@ -39,7 +39,7 @@ You must install `redis-cli` utility first.
 
 `type: redis`
 
-- `mode` - Redis dump mode, default: `sync`
+- `mode` - Redis dump mode, default: `copy`
   - `sync` - For remote Redis server use sync to export.
   - `copy` - For local Redis server use copy, just copy Redis `dump.db`
 - `host` - Redis server host, if use host, default: `127.0.0.1`


### PR DESCRIPTION
Current doc says `mode` for redis is by default `sync`. However, according to the code and practices, it is `copy`.

https://github.com/gobackup/gobackup/blob/43ba3e85b04f5b33abf31bf782121f99cc8b6115/database/redis.go#L51