### PR TITLE
Fix etc config path

### DIFF
--- a/pages/configuration/index.mdx
+++ b/pages/configuration/index.mdx
@@ -3,7 +3,7 @@
 GoBackup will read config from following paths:
 
 - `~/.gobackup/gobackup.yml`
-- `/etc/gobackup.yml`
+- `/etc/gobackup/gobackup.yml`
 
 You must use [YAML](http://yaml.org) format.
 


### PR DESCRIPTION
Fix the config lookup path `/etc/gobackup.yml` to `/etc/gobackup/gobackup.yml`

Refs:
- https://github.com/gobackup/gobackup?tab=readme-ov-file#configuration
- https://gobackup.github.io/getting-started#init-config